### PR TITLE
PPI details changes

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -116,8 +116,9 @@
           "builder": "@angular-devkit/build-angular:server",
           "options": {
             "outputPath": "dist/server",
-            "main": "src/main.server.ts",
-            "tsConfig": "tsconfig.server.json"
+            "main": "server.ts",
+            "tsConfig": "tsconfig.server.json",
+            "externalDependencies": ["@firebase/firestore"]
           },
           "configurations": {
             "production": {
@@ -144,6 +145,32 @@
               "browserTarget": "pharos:build:production",
               "serverTarget": "pharos:server:production"
             }
+          }
+        },
+        "serve-ssr": {
+          "builder": "@nguniversal/builders:ssr-dev-server",
+          "options": {
+            "browserTarget": "pharos:build",
+            "serverTarget": "pharos:server"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "pharos:build:production",
+              "serverTarget": "pharos:server:production"
+            }
+          }
+        },
+        "prerender": {
+          "builder": "@nguniversal/builders:prerender",
+          "options": {
+            "browserTarget": "pharos:build:production",
+            "serverTarget": "pharos:server:production",
+            "routes": [
+              "/"
+            ]
+          },
+          "configurations": {
+            "production": {}
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -12,13 +12,15 @@
     "e2e": "ng e2e",
     "build:appshell": "ng run pharos:app-shell:production",
     "compodoc": "npx compodoc -p tsconfig.app.json -s -w --theme material",
-    "build:ssr": "npm run build:client-and-server-bundles && npm run webpack:server",
-    "serve:ssr": "node dist/server.js",
+    "build:ssr": "ng build --prod && ng run pharos:server:production",
+    "serve:ssr": "node dist/server/main.js",
     "build:client-and-server-bundles": "node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng build pharos --prod && ng run pharos:server:production",
     "webpack:server": "webpack --config webpack.server.config.js --progress --colors",
     "postinstall": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points",
     "scully": "scully",
-    "scully:serve": "scully serve"
+    "scully:serve": "scully serve",
+    "dev:ssr": "ng run pharos:serve-ssr",
+    "prerender": "ng run pharos:prerender"
   },
   "private": true,
   "dependencies": {
@@ -71,12 +73,14 @@
     "zone.js": "~0.10.2"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.900.0",
+    "@angular-devkit/build-angular": "0.900.7",
+    "@angular-devkit/build-optimizer": "0.900.7",
     "@angular/cli": "~9.0.0",
     "@angular/compiler-cli": "9.0.5",
     "@angular/language-service": "9.0.5",
     "@compodoc/compodoc": "^1.1.11",
     "@firebase/testing": "^0.16.13",
+    "@nguniversal/builders": "^9.1.0",
     "@types/express": "^4.0.39",
     "@types/jasmine": "~3.5.8",
     "@types/jasminewd2": "~2.0.6",

--- a/src/app/models/facet.ts
+++ b/src/app/models/facet.ts
@@ -93,66 +93,6 @@ export class Facet {
   }
 
   /**
-   * retrieve the full list of facets for each of the paths
-   * @param path
-   */
-  static getFacetList(path){
-    if (path == "targets") {
-      return Facet.TargetFacets;
-    } else if (path == "diseases") {
-      return Facet.DiseaseFacets;
-    } else if (path == "ligands") {
-      return Facet.LigandFacets;
-    }
-  }
-  /**
-   * List of all facets to collect when opening the Full Page panel of facets of targets
-   */
-  static TargetFacets = [
-    "Target Development Level",
-    "UniProt Keyword",
-    "Family",
-    "Indication",
-    "Monarch Disease",
-    "UniProt Disease",
-    "Ortholog",
-    "IMPC Phenotype",
-    "JAX/MGI Phenotype",
-    "GO Process",
-    "GO Component",
-    "GO Function",
-    "GWAS",
-    "Expression: CCLE",
-    "Expression: HCA RNA",
-    "Expression: HPM Protein",
-    "Expression: HPA",
-    "Expression: JensenLab Experiment HPA",
-    "Expression: HPM Gene",
-    "Expression: JensenLab Experiment HPA-RNA",
-    "Expression: JensenLab Experiment GNF",
-    "Expression: Consensus",
-    "Expression: JensenLab Experiment Exon array",
-    "Expression: JensenLab Experiment RNA-seq",
-    "Expression: JensenLab Experiment UniGene",
-    "Expression: UniProt Tissue",
-    "Expression: JensenLab Knowledge UniProtKB-RC",
-    "Expression: JensenLab Text Mining",
-    "Expression: JensenLab Experiment Cardiac proteome",
-    "Expression: Cell Surface Protein Atlas"];
-
-
-  /**
-   * List of all facets to collect when opening the Full Page panel of facets of diseases
-   */
-  static DiseaseFacets = ["Data Source", "Drug", "Target Development Level"];
-
-
-  /**
-   * List of all facets to collect when opening the Full Page panel of facets of ligands
-   */
-  static LigandFacets = ["type", "activity"];
-
-  /**
    * retrieves a query object for getting all the facet options for a single facet for a list of targets / diseases / ligands
    * @param path
    */

--- a/src/app/models/interaction-details.spec.ts
+++ b/src/app/models/interaction-details.spec.ts
@@ -1,0 +1,7 @@
+import { InteractionDetails } from './interaction-details';
+
+describe('InteractionDetails', () => {
+  it('should create an instance', () => {
+    expect(new InteractionDetails()).toBeTruthy();
+  });
+});

--- a/src/app/models/interaction-details.ts
+++ b/src/app/models/interaction-details.ts
@@ -1,0 +1,9 @@
+export class InteractionDetails {
+  score?: number;
+  p_int?: number;
+  p_ni?: number;
+  p_wrong?: number;
+  interaction_type?: string;
+  evidence?: string;
+  dataSources?: string[];
+}

--- a/src/app/models/target-components.ts
+++ b/src/app/models/target-components.ts
@@ -159,6 +159,15 @@ export const TARGETLISTFIELDS = gql`
     idgTDL: tdl
     novelty
     description
+    interactionDetails: ppiTargetInteractionDetails{
+      ppitypes
+      interaction_type
+      evidence
+      score
+      p_ni
+      p_int
+      p_wrong
+    }
     uniProtFunction: props (name: "UniProt Function"){
       value
     }
@@ -195,6 +204,10 @@ const TARGET_PPI_QUERY = gql`
     targets: target(q: { sym: $term, uniprot: $term, stringid: $term }) {
       ...targetsListFields
       ppis (top: $ppistop, skip: $ppisskip){
+        props{
+          name
+          value
+        }
         target{
           ...targetsListFields
         }
@@ -280,6 +293,10 @@ export const TARGETDETAILSFIELDS = gql`
       name
     }
     ppis (top: $ppistop, skip: $ppisskip){
+      props{
+        name
+        value
+      }
       target{
         ...targetsListFields
       }

--- a/src/app/pharos-main/data-details/target-details/panels/protein-protein-panel/protein-protein-panel.component.html
+++ b/src/app/pharos-main/data-details/target-details/panels/protein-protein-panel/protein-protein-panel.component.html
@@ -13,9 +13,22 @@
         <div fxFlex="95" class="headerContainer">
         <span class="mat-title" [matTooltip]=description
               [matTooltipClass]="'pharos-tooltip'">Protein-Protein Interactions ({{target.ppiCount}})</span>
-          <ncats-property-display class="mat-title" [showLabel]="false" matTooltip="Open the target list with the interacting proteins"
-                                  [property]="{term:'Explore Interacting Targets', internalLink:'/targets', queryParams:{ppiTarget:target.gene}}">
-          </ncats-property-display>
+          <ul>
+            <li>
+              <ncats-property-display class="mat-title" [showLabel]="false"
+                                      matTooltip="Open the target list with the interacting proteins" matTooltipClass="pharos-tooltip"
+                                      matTooltipPosition="after"
+                                      [property]="{term:'Explore Interacting Targets', internalLink:'/targets', queryParams:{ppiTarget:target.gene}}">
+              </ncats-property-display>
+            </li>
+            <li>
+              <ncats-property-display class="mat-title" [showLabel]="false"
+                                      matTooltip="See interacting proteins on String-db.org" matTooltipClass="pharos-tooltip"
+                                      matTooltipPosition="after"
+                                      [property]="{term:'See Interactions on String-DB', externalLink:'https://string-db.org/network/homo_sapiens/' + target.gene}">
+              </ncats-property-display>
+            </li>
+          </ul>
         </div>
         <div fxFlex="5">
           <pharos-help-panel-trigger [origin]="'ppi'"

--- a/src/app/pharos-main/data-details/target-details/panels/protein-protein-panel/protein-protein-panel.component.scss
+++ b/src/app/pharos-main/data-details/target-details/panels/protein-protein-panel/protein-protein-panel.component.scss
@@ -1,7 +1,7 @@
 .target-grid {
   display: grid;
   grid-auto-rows: max-content;
-  grid-template-columns: repeat(auto-fill, minmax(18%, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(19%, 1fr));
   grid-gap: .5em;
   justify-items: center;
   padding-left: 2.5vw;
@@ -12,8 +12,6 @@
   margin-bottom: 1em;
   min-width: 100%;
   max-width: 100%;
-  min-height: 110%;
- // height:20vh;
 }
 
 .radar-row {
@@ -43,6 +41,4 @@
 }
 
 .headerContainer{
-  display: flex;
-  justify-content: space-between;
 }

--- a/src/app/pharos-main/data-list/cards/long-target-card/gene-details/gene-details.component.html
+++ b/src/app/pharos-main/data-list/cards/long-target-card/gene-details/gene-details.component.html
@@ -1,0 +1,7 @@
+<mat-card-subtitle>Gene Details</mat-card-subtitle>
+<div class="subsection">
+  <ncats-property-display
+    [property]="{term: target.gene, label: 'Gene', tooltip: getTooltip('gene')}"></ncats-property-display>
+  <ncats-property-display [property]="{term: target.accession, label: 'UniProt ID', tooltip: getTooltip('uniprot')}"></ncats-property-display>
+  <ncats-property-display [property]="{term: target.idgFamily, label: 'Family', tooltip: getTooltip('family')}"></ncats-property-display>
+</div>

--- a/src/app/pharos-main/data-list/cards/long-target-card/gene-details/gene-details.component.ts
+++ b/src/app/pharos-main/data-list/cards/long-target-card/gene-details/gene-details.component.ts
@@ -1,0 +1,30 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {DynamicPanelComponent} from "../../../../../tools/dynamic-panel/dynamic-panel.component";
+import {Target} from "../../../../../models/target";
+
+@Component({
+  selector: 'pharos-gene-details',
+  templateUrl: './gene-details.component.html',
+  styleUrls: ['../long-target-card.component.scss']
+})
+
+export class GeneDetailsComponent extends DynamicPanelComponent implements OnInit{
+  constructor() {
+    super();
+  }
+  @Input() target?: Target;
+  @Input() apiSources: any[];
+
+  ngOnInit(): void {
+  }
+  getTooltip(label: string): string {
+    if (this.apiSources) {
+      const tooltip = this.apiSources.filter(source => source.field === label);
+      if (tooltip.length) {
+        return tooltip[0].description;
+      } else {
+        return null;
+      }
+    }
+  }
+}

--- a/src/app/pharos-main/data-list/cards/long-target-card/interaction-details/interaction-details.component.html
+++ b/src/app/pharos-main/data-list/cards/long-target-card/interaction-details/interaction-details.component.html
@@ -1,0 +1,25 @@
+<mat-card-subtitle>Interaction Details</mat-card-subtitle>
+<div class="subsection" *ngIf="target.interactionDetails.score">
+  <div class="list-header">StringDB stats
+    <div class="list-item">
+      <ncats-property-display
+        [property]="{term: target.interactionDetails.score, label: 'score', tooltip: getTooltip('stringScore')}"></ncats-property-display>
+    </div>
+  </div>
+</div>
+<div class="subsection" *ngIf="target.interactionDetails.p_int">
+  <div class="list-header">BioPlex stats
+    <div class="list-item">
+      <ncats-property-display
+        [property]="{term: target.interactionDetails.p_int, label: 'p_int', tooltip: getTooltip('p_int')}"></ncats-property-display>
+    </div>
+    <div class="list-item">
+      <ncats-property-display
+        [property]="{term: target.interactionDetails.p_ni, label: 'p_ni', tooltip: getTooltip('p_ni')}"></ncats-property-display>
+    </div>
+    <div class="list-item">
+      <ncats-property-display
+        [property]="{term: target.interactionDetails.p_wrong, label: 'p_wrong', tooltip: getTooltip('p_wrong')}"></ncats-property-display>
+    </div>
+  </div>
+</div>

--- a/src/app/pharos-main/data-list/cards/long-target-card/interaction-details/interaction-details.component.ts
+++ b/src/app/pharos-main/data-list/cards/long-target-card/interaction-details/interaction-details.component.ts
@@ -1,0 +1,19 @@
+import {Component, OnInit} from '@angular/core';
+import {GeneDetailsComponent} from "../gene-details/gene-details.component";
+
+@Component({
+  selector: 'pharos-interaction-details',
+  templateUrl: './interaction-details.component.html',
+  styleUrls: ['../long-target-card.component.scss']
+})
+export class InteractionDetailsComponent extends GeneDetailsComponent implements OnInit {
+
+  constructor() {
+    super();
+
+  }
+
+  ngOnInit(): void {
+    super.ngOnInit();
+  }
+}

--- a/src/app/pharos-main/data-list/cards/long-target-card/knowledge-metrics/knowledge-metrics.component.html
+++ b/src/app/pharos-main/data-list/cards/long-target-card/knowledge-metrics/knowledge-metrics.component.html
@@ -1,0 +1,13 @@
+<mat-card-subtitle>Knowledge Metrics</mat-card-subtitle>
+<div class="subsection">
+  <ncats-property-display
+    [property]="{term: this.target.ppiCount, label: 'PPIs', tooltip: getTooltip('ppis')}"></ncats-property-display>
+  <ncats-property-display
+    [property]="{term: target.jensenScore, label: 'PubMed Score', tooltip: getTooltip('pubmed')}"></ncats-property-display>
+  <ncats-property-display
+    [property]="{term: target.pubTatorScore, label: 'PubTator Score', tooltip: getTooltip('pubtator')}"></ncats-property-display>
+  <ncats-property-display
+    [property]="{term: target.antibodyCount, label: 'Antibody Count', tooltip: getTooltip('abcount')}"></ncats-property-display>
+  <ncats-property-display
+    [property]="{term: target.novelty, label: 'Novelty', tooltip: getTooltip('novelty')}"></ncats-property-display>
+</div>

--- a/src/app/pharos-main/data-list/cards/long-target-card/knowledge-metrics/knowledge-metrics.component.ts
+++ b/src/app/pharos-main/data-list/cards/long-target-card/knowledge-metrics/knowledge-metrics.component.ts
@@ -1,0 +1,18 @@
+import {Component, OnInit} from '@angular/core';
+import {GeneDetailsComponent} from "../gene-details/gene-details.component";
+
+@Component({
+  selector: 'pharos-knowledge-metrics',
+  templateUrl: './knowledge-metrics.component.html',
+  styleUrls: ['../long-target-card.component.scss']
+})
+
+export class KnowledgeMetricsComponent extends GeneDetailsComponent implements OnInit {
+  constructor() {
+    super();
+  }
+
+  ngOnInit(): void {
+    super.ngOnInit();
+  }
+}

--- a/src/app/pharos-main/data-list/cards/long-target-card/long-target-card.component.html
+++ b/src/app/pharos-main/data-list/cards/long-target-card/long-target-card.component.html
@@ -1,0 +1,36 @@
+<mat-card *ngIf="target" class="container">
+  <mat-card-content>
+    <div class="">
+      <div fxFlex="95" class="toprow">
+        <mat-checkbox *ngIf="loggedIn" (click)="$event.stopPropagation()"
+                      (change)="$event ? this.toggleSelection($event) : null"
+                      [checked]="this.selected">
+        </mat-checkbox>
+        <pharos-idg-level-indicator [level]="target.idgTDL" [matTooltip]="getTooltip('tdl')"></pharos-idg-level-indicator>
+        <span class="mat-card-title" [matTooltip]="'See details for ' + target.gene"
+             routerLink='/targets/{{target.accession}}' target="_blank">
+          {{target?.name}}
+        </span>
+      </div>
+      <div>
+        <pharos-help-panel-trigger [origin]="'targetList'"></pharos-help-panel-trigger>
+      </div>
+    </div>
+    <div class="target-details">
+      <div class="section">
+        <pharos-gene-details [target]="target" [apiSources]="apiSources"></pharos-gene-details>
+      </div>
+      <div class="section">
+        <pharos-knowledge-metrics [target]="target" [apiSources]="apiSources"></pharos-knowledge-metrics>
+      </div>
+      <div class="section interaction_details" *ngIf="target.interactionDetails">
+        <pharos-interaction-details [target]="target" [apiSources]="apiSources"></pharos-interaction-details>
+      </div>
+      <div class="section radar-chart">
+        <mat-card-subtitle>Illumination Graph</mat-card-subtitle>
+        <pharos-radar-chart [size]="'small'"
+                            *ngIf=target.hgdata [data]="[target.hgdata]" [matTooltip]="getTooltip('illuminationGraph')"></pharos-radar-chart>
+      </div>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/src/app/pharos-main/data-list/cards/long-target-card/long-target-card.component.scss
+++ b/src/app/pharos-main/data-list/cards/long-target-card/long-target-card.component.scss
@@ -1,0 +1,53 @@
+.container {
+  display: flex;
+  box-sizing: border-box;
+}
+
+.mat-card-title{
+  cursor:pointer;
+}
+
+.mat-card-content{
+  width: 100%;
+}
+
+.mat-card-subtitle{
+  font-size: x-large;
+}
+
+.container:hover {
+  background-color: #f6f6f6;
+}
+
+.toprow{
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  justify-content: start;
+}
+
+.target-details {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  box-sizing: border-box;
+}
+
+.list-header{
+  margin-top: 10px;
+}
+
+.list-item{
+  margin-left: 10px;
+}
+
+.section{
+  max-width: 33%;
+  min-width: 20%;
+  padding: 20px;
+}
+
+.radar-chart {
+  width: 150px;
+  height: 150px;
+}

--- a/src/app/pharos-main/data-list/cards/long-target-card/long-target-card.component.spec.ts
+++ b/src/app/pharos-main/data-list/cards/long-target-card/long-target-card.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LongTargetCardComponent } from './long-target-card.component';
+
+describe('LongTargetCardComponent', () => {
+  let component: LongTargetCardComponent;
+  let fixture: ComponentFixture<LongTargetCardComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LongTargetCardComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LongTargetCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pharos-main/data-list/cards/long-target-card/long-target-card.component.ts
+++ b/src/app/pharos-main/data-list/cards/long-target-card/long-target-card.component.ts
@@ -1,0 +1,30 @@
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {Target} from "../../../../models/target";
+import {DynamicPanelComponent} from "../../../../tools/dynamic-panel/dynamic-panel.component";
+
+@Component({
+  selector: 'pharos-long-target-card',
+  templateUrl: './long-target-card.component.html',
+  styleUrls: ['./long-target-card.component.scss']
+})
+
+export class LongTargetCardComponent extends DynamicPanelComponent implements OnInit {
+
+  @Input() target?: Target;
+  @Input() selected: boolean;
+  @Input() loggedIn: boolean;
+  @Input() apiSources: any[];
+
+  @Output() selectionChanged = new EventEmitter<boolean>();
+
+  constructor() {
+    super();
+  }
+
+  ngOnInit(): void {
+  }
+  toggleSelection($event: any){
+    this.selected = !this.selected;
+    this.selectionChanged.emit(this.selected);
+  }
+}

--- a/src/app/pharos-main/data-list/cards/target-card/target-card.component.html
+++ b/src/app/pharos-main/data-list/cards/target-card/target-card.component.html
@@ -1,33 +1,40 @@
 <mat-card *ngIf="target" routerLink='/targets/{{target.accession}}' target="_blank" class="target-card">
-      <div class="target-content">
-    <div fxLayout="row wrap" class ="tkrow" fxLayoutAlign="space-around start">
+  <div class="target-content">
+    <div fxLayout="row wrap" class="tkrow" fxLayoutAlign="space-around start">
       <div fxFlex="48">
         <pharos-idg-level-indicator [level]="target?.idgTDL"></pharos-idg-level-indicator>
       </div>
       <div fxFlex="48" fxLayoutAlign="end">
-        <span class ="mat-title gene">{{target?.gene}}</span>
+        <span class="mat-title gene">{{target?.gene}}</span>
       </div>
     </div>
     <mat-divider></mat-divider>
-    <div fxLayout="row" fxLayoutAlign="start center" class = "name-row">
+    <div fxLayout="row" fxLayoutAlign="start center" class="name-row">
       <div fxFlex="95">
         <span class="mat-title target-link">{{target?.name}}</span>
       </div>
     </div>
-    <div fxLayout="row" class ="radar-row target-card-radar" fxLayoutAlign="space-around stretch">
+    <div class="target-lower-content">
+    <div fxLayout="row" class="radar-row target-card-radar" fxLayoutAlign="space-around stretch">
       <div fxFlex="95">
-    <pharos-radar-chart [size]="'small'" *ngIf = target.hgdata [data]="[target.hgdata]"></pharos-radar-chart>
+        <pharos-radar-chart [size]="'small'" *ngIf=target.hgdata [data]="[target.hgdata]"></pharos-radar-chart>
       </div>
     </div>
-<!--    <div fxLayout="row" class ="tkrow" fxLayoutAlign="start stretch" *ngIf="showKnowledge">
-      <div fxFlex="95">
-    <pharos-knowledge-table *ngIf = knowledge [data] = knowledge></pharos-knowledge-table>
+    <!--    <div fxLayout="row" class ="tkrow" fxLayoutAlign="start stretch" *ngIf="showKnowledge">
+          <div fxFlex="95">
+        <pharos-knowledge-table *ngIf = knowledge [data] = knowledge></pharos-knowledge-table>
+          </div>
+        </div>-->
+      <div fxLayout="row" fxLayoutAlign="start stretch">
+        <div fxFlex="95">
+          <ncats-property-display *ngIf="target?.idgFamily"
+                                  [property]="{label:'Family', term:target?.idgFamily}"></ncats-property-display>
+          <div *ngFor="let prop of target.properties">
+            <ncats-property-display *ngIf="prop.label != 'tdl' && prop.label != 'fam'"
+                                    [property]="prop"></ncats-property-display>
+          </div>
+        </div>
       </div>
-    </div>-->
-      </div>
-  <div fxLayout="row" fxLayoutAlign="start stretch" >
-    <div fxFlex="95">
-      <span>Target Family: {{target?.idgFamily}}</span>
     </div>
   </div>
 </mat-card>

--- a/src/app/pharos-main/data-list/cards/target-card/target-card.component.scss
+++ b/src/app/pharos-main/data-list/cards/target-card/target-card.component.scss
@@ -29,8 +29,7 @@ font-size: .9em;
 }
 
 .target-card {
-  cursor: pointer;
-  min-height: 80%;
+  //min-height: 80%;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -38,6 +37,13 @@ font-size: .9em;
 
 .target-content {
   flex: 1 0 auto;
+}
+
+.target-lower-content {
+  //flex: 1 0 auto;
+  //display: flex;
+  //flex-direction: column;
+  //justify-content: space-between;
 }
 
 mat-divider {

--- a/src/app/pharos-main/data-list/tables/target-table/target-table.component.html
+++ b/src/app/pharos-main/data-list/tables/target-table/target-table.component.html
@@ -1,92 +1,106 @@
 <section>
-<div *ngIf="targets">
-  <mat-toolbar [color]="'primary'" class="target-table-toolbar" *ngIf="showToolbar">
-    <div class=pharos-display-1 *ngIf="showLabel">Targets <span *ngIf="pageData">({{pageData.total}})</span>
-    </div>
-    <div fxFlex></div>
-    <div fxFlex="5">
-      <button mat-icon-button [matMenuTriggerFor]="appMenu" aria-label="target table tools">
-        <mat-icon>apps</mat-icon>
-      </button>
-      <mat-menu #appMenu="matMenu">
-        <button mat-menu-item (click)="batchUpload()">
-          <mat-icon>create</mat-icon>
-          Upload Target List
+  <div *ngIf="targets">
+    <mat-toolbar [color]="'primary'" class="target-table-toolbar" *ngIf="showToolbar">
+      <div class=pharos-display-1 *ngIf="showLabel">Targets <span *ngIf="pageData">({{pageData.total}})</span>
+      </div>
+      <div fxFlex></div>
+      <div fxFlex="5">
+        <button mat-icon-button [matMenuTriggerFor]="appMenu" aria-label="target table tools">
+          <mat-icon>apps</mat-icon>
         </button>
-                <!--<span matTooltip= "Please select 2-4 targets to compare"-->
-                      <!--[matTooltipDisabled] = "!rowSelection.isEmpty()">-->
-                <!--<button mat-menu-item-->
-                        <!--(click)="compareTargets()"-->
-                        <!--[disabled]="rowSelection.isEmpty() || (rowSelection.selected.length < 2 || rowSelection.selected.length > 4)"-->
-                <!--&gt;<mat-icon>swap_horiz</mat-icon>Compare Targets</button>-->
-                <!--</span>-->
+        <mat-menu #appMenu="matMenu">
+          <button mat-menu-item (click)="batchUpload()">
+            <mat-icon>create</mat-icon>
+            Upload Target List
+          </button>
+          <!--<span matTooltip= "Please select 2-4 targets to compare"-->
+          <!--[matTooltipDisabled] = "!rowSelection.isEmpty()">-->
+          <!--<button mat-menu-item-->
+          <!--(click)="compareTargets()"-->
+          <!--[disabled]="rowSelection.isEmpty() || (rowSelection.selected.length < 2 || rowSelection.selected.length > 4)"-->
+          <!--&gt;<mat-icon>swap_horiz</mat-icon>Compare Targets</button>-->
+          <!--</span>-->
 
-                <button mat-menu-item
-                        *ngIf="loggedIn === true"
-                        (click)="saveTargets()"
-                        [disabled]="rowSelection.isEmpty()">
-                  <mat-icon>save</mat-icon>Save Selected
-                </button>
-        <button mat-menu-item
-                *ngIf="loggedIn === true"
-                (click)="createTopic()"
-                [disabled]="rowSelection.isEmpty()">
-          <mat-icon>bubble_chart</mat-icon>
-          Generate Topic</button>
-<!--                <button mat-menu-item
-                        *ngIf="loggedIn === true"
-                        (click)="saveQuery()"
-                ><mat-icon>save_alt</mat-icon>Save Query</button>-->
-      </mat-menu>
+          <button mat-menu-item
+                  *ngIf="loggedIn === true"
+                  (click)="saveTargets()"
+                  [disabled]="rowSelection.isEmpty()">
+            <mat-icon>save</mat-icon>
+            Save Selected
+          </button>
+          <button mat-menu-item
+                  *ngIf="loggedIn === true"
+                  (click)="createTopic()"
+                  [disabled]="rowSelection.isEmpty()">
+            <mat-icon>bubble_chart</mat-icon>
+            Generate Topic
+          </button>
+          <!--                <button mat-menu-item
+                                  *ngIf="loggedIn === true"
+                                  (click)="saveQuery()"
+                          ><mat-icon>save_alt</mat-icon>Save Query</button>-->
+        </mat-menu>
+      </div>
+    </mat-toolbar>
+    <div fxLayout="row" fxLayout.lt-sm="column" fxLayoutAlign="space-between center"
+         class="paginator-row">
+      <div fxFlex="20" *ngIf="loggedIn">
+        <mat-checkbox (click)="$event.stopPropagation()" [matTooltip]="this.selectionTooltip() || 'Select all targets'"
+                      (change)="$event ? this.toggleAll($event) : null"
+                      [checked]="this.allSelected()"
+                      [indeterminate]="this.someSelected()">Selected {{this.rowSelection.selected.length}} targets
+        </mat-checkbox>
+      </div>
+      <div class="sort-select">
+        <mat-form-field>
+          <mat-select [(value)]="this.selectedSortObject" placeholder="Sort" (valueChange)="sortChanged($event)"
+                      matTooltip="Sort the target list">
+            <mat-option>Default</mat-option>
+            <mat-option *ngFor="let sortKey of this.sortMap.keys()" [value]="this.sortMap.get(sortKey)">
+              {{sortKey}}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+        <button mat-button *ngIf="previousSortObject" (click)="toggleSortOrder()">
+          <mat-icon *ngIf="previousSortObject.order === 'desc'" matTooltip="descending">keyboard_arrow_down</mat-icon>
+          <mat-icon *ngIf="previousSortObject.order === 'asc'" matTooltip="ascending">keyboard_arrow_up</mat-icon>
+        </button>
+      </div>
+      <div fxFlex="75" fxFlexAlign="end">
+        <mat-paginator
+          [pageSize]=pageData.top
+          [pageIndex]="pageData.skip / pageData.top"
+          [length]=pageData.total
+          [pageSizeOptions]="[10, 20, 60, 100]"
+          [showFirstLastButtons]="true"
+          (page)="changePage($event)"></mat-paginator>
+      </div>
     </div>
-  </mat-toolbar>
-  <div fxLayout="row" fxLayout.lt-sm="column" fxLayoutAlign="space-between center"
-       class="paginator-row">
-    <div fxFlex="45" fxLayoutAlign.lt-sm="center">
-       <!-- <mat-checkbox
-          (change)="$event ? selectAll() : null">
-          Select All {{pageData?.total}}
-        </mat-checkbox>-->
+    <div *ngIf="!isSmallScreen">
+      <div *ngFor="let target of targets">
+        <pharos-long-target-card [target]="target" [selected]="isSelected(target)"
+                                 (selectionChanged)="updateTargetSelection(target, $event)"
+                                 [loggedIn]="loggedIn"
+                                 [apiSources]="apiSources"></pharos-long-target-card>
+      </div>
     </div>
-    <div fxFlex="45" fxFlexAlign="end">
-      <mat-paginator
-        [pageSize]= pageData.top
-        [pageIndex]="pageData.skip / pageData.top"
-        [length]= pageData.total
-        [pageSizeOptions]="[10, 20, 60, 100]"
-        [showFirstLastButtons]="true"
-        (page)="changePage($event)"></mat-paginator>
+    <div class="target-grid" *ngIf="isSmallScreen">
+      <div *ngFor="let target of targets">
+        <pharos-target-card [target]="target"></pharos-target-card>
+      </div>
+    </div>
+    <div fxLayout="row" fxLayout.lt-sm="column" fxLayoutGap="10px" fxLayoutAlign="space-around start" class="body-row">
+      <div fxFlex="45">
+      </div>
+      <div fxFlex="45" fxFlexAlign="end">
+        <mat-paginator
+          [pageSize]=pageData.top
+          [pageIndex]="pageData.skip / pageData.top"
+          [length]=pageData.total
+          [pageSizeOptions]="[10, 20, 60, 100]"
+          [showFirstLastButtons]="true"
+          (page)="changePage($event)"></mat-paginator>
+      </div>
     </div>
   </div>
-  <div *ngIf="!isSmallScreen">
-    <pharos-generic-table *ngIf="targetObjs"
-                          [pageData]="pageData"
-                          [showPaginator]="false"
-                          [fieldsConfig]="fieldsData"
-                          [data]="targetObjs"
-                          [selectableRows]= "loggedIn"
-                          (rowSelectionChange) = "setSelectedTargets($event)"
-                          (sortChange)="changeSort($event)"
-                          (pageChange)="changePage($event)">
-    </pharos-generic-table>
-  </div>
-  <div class="target-grid" *ngIf="isSmallScreen" >
-    <div *ngFor="let target of targets">
-      <pharos-target-card [target]="target"></pharos-target-card>
-    </div>
-  </div>
-  <div fxLayout="row" fxLayout.lt-sm="column" fxLayoutGap="10px" fxLayoutAlign="space-around start" class="body-row">
-    <div fxFlex="45">
-    </div>
-    <div fxFlex="45" fxFlexAlign="end">
-      <mat-paginator
-        [pageSize]= pageData.top
-        [pageIndex]="pageData.skip / pageData.top"
-        [length]= pageData.total
-        [pageSizeOptions]="[10, 20, 60, 100]"
-        [showFirstLastButtons]="true"
-        (page)="changePage($event)"></mat-paginator>
-    </div>
-  </div>
-</div>
 </section>

--- a/src/app/pharos-main/data-list/tables/target-table/target-table.component.scss
+++ b/src/app/pharos-main/data-list/tables/target-table/target-table.component.scss
@@ -13,6 +13,12 @@
   padding-right: 1vw;
 }
 
+.sort-select{
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  justify-content: space-around;
+}
 
 .pharos-display-1 {
   font: 400 34px/40px Roboto, "Helvetica Neue", sans-serif;

--- a/src/app/pharos-main/modules/targets/target-list.module.ts
+++ b/src/app/pharos-main/modules/targets/target-list.module.ts
@@ -3,6 +3,7 @@ import {CommonModule} from '@angular/common';
 import {TargetListRoutingModule} from './target-list-routing.module';
 import {IDG_LEVEL_TOKEN, RADAR_CHART_TOKEN, TargetTableComponent} from '../../data-list/tables/target-table/target-table.component';
 import {TargetCardComponent} from '../../data-list/cards/target-card/target-card.component';
+import {LongTargetCardComponent} from "../../data-list/cards/long-target-card/long-target-card.component";
 import {InjectedRadarChartComponent} from '../../data-list/tables/target-table/injected-radar-chart/injected-radar-chart.component';
 import {SharedModule} from '../../../shared/shared.module';
 import {CommonToolsModule} from '../../../tools/common-tools.module';
@@ -10,11 +11,19 @@ import {SharedListModule} from '../../../shared/shared-list.module';
 import {TOKENS} from '../../../../config/component-tokens';
 import {IdgLevelIndicatorComponent} from '../../../tools/idg-level-indicator/idg-level-indicator.component';
 import {TopicSaveModalComponent} from '../../data-list/tables/target-table/topic-save-modal/topic-save-modal.component';
+import {GeneDetailsComponent} from "../../data-list/cards/long-target-card/gene-details/gene-details.component";
+import {InteractionDetailsComponent} from "../../data-list/cards/long-target-card/interaction-details/interaction-details.component";
+import {KnowledgeMetricsComponent} from "../../data-list/cards/long-target-card/knowledge-metrics/knowledge-metrics.component";
+import {HelpPanelComponent} from "../../../tools/help-panel/help-panel.component";
 
 @NgModule({
   declarations: [
     TargetTableComponent,
     TargetCardComponent,
+    LongTargetCardComponent,
+    GeneDetailsComponent,
+    InteractionDetailsComponent,
+    KnowledgeMetricsComponent,
     InjectedRadarChartComponent,
     TopicSaveModalComponent
   ],
@@ -28,11 +37,16 @@ import {TopicSaveModalComponent} from '../../data-list/tables/target-table/topic
   providers: [
     {provide: TOKENS.TARGET_TABLE_COMPONENT, useValue: TargetTableComponent},
     {provide: IDG_LEVEL_TOKEN, useValue: IdgLevelIndicatorComponent},
-    {provide: RADAR_CHART_TOKEN, useValue: InjectedRadarChartComponent}
+    {provide: RADAR_CHART_TOKEN, useValue: InjectedRadarChartComponent},
+    {provide: TOKENS.PHAROS_HELPPANEL_COMPONENT, useValue: HelpPanelComponent}
   ],
   exports: [
     TargetTableComponent,
-    TargetCardComponent
+    TargetCardComponent,
+    LongTargetCardComponent,
+    GeneDetailsComponent,
+    InteractionDetailsComponent,
+    KnowledgeMetricsComponent
   ]
 })
 export class TargetTableModule { }

--- a/src/app/pharos-main/resolvers/data-details.resolver.ts
+++ b/src/app/pharos-main/resolvers/data-details.resolver.ts
@@ -4,7 +4,7 @@ import { Observable , of} from 'rxjs';
 import {PharosApiService} from '../../pharos-services/pharos-api.service';
 import {LoadingService} from '../../pharos-services/loading.service';
 import {PharosBase, Serializer} from '../../models/pharos-base';
-import {map} from 'rxjs/internal/operators';
+import {catchError, map} from 'rxjs/internal/operators';
 
 /**
  * resolves the details for a specific object
@@ -40,6 +40,10 @@ export class DataDetailsResolver implements Resolve<any> {
           res.data[route.data.path] = tobj;
           res.data[`${[route.data.path]}Props`] = serializer._asProperties(tobj);
           return res.data;
+        }),
+        catchError(err => {
+          alert(JSON.stringify(err));
+          return null;
         })
       );
     }

--- a/src/app/pharos-services/pharos-api.service.ts
+++ b/src/app/pharos-services/pharos-api.service.ts
@@ -396,7 +396,7 @@ export class PharosApiService {
 // todo: this is probably not ideal , although it returns a more useful query than the initial list query
   getAllFacets(path: string, params: ParamMap): Observable<any> {
     let variables = this.getVariablesForFacetQuery(path, params);
-    variables = {facets: Facet.getFacetList(path), ...variables};
+    variables = {facets: "all", ...variables};
 
     const docid: string = params.get('collection');
     if (!!docid) {
@@ -557,6 +557,11 @@ export class PharosApiService {
               this.queryString = val;
               break;
             }
+            case 'sortColumn':
+              const filter: any = ret.filter ? ret.filter : {};
+              filter.order = val;
+              ret.filter = filter;
+              break;
             case 'collection': {
               break;
             }

--- a/src/app/tools/generic-table/components/property-display/data-property.ts
+++ b/src/app/tools/generic-table/components/property-display/data-property.ts
@@ -29,6 +29,11 @@ export class DataProperty {
   href?: string;
 
   /**
+   * optional tooltip to show when hovering the label
+   */
+  tooltip?: string;
+
+  /**
    * should column be sortable
    */
   sortable?: boolean;

--- a/src/app/tools/generic-table/components/property-display/property-display.component.html
+++ b/src/app/tools/generic-table/components/property-display/property-display.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="property">
-  <span class="" *ngIf="showLabel" matTooltip="{{property.label}}"><b>{{property.label}}:&nbsp;</b></span>
+  <span class="" *ngIf="showLabel" matTooltip="{{property.tooltip || property.label}}"><b>{{property.label}}:&nbsp;</b></span>
 <ng-container
   *ngIf="property.internalLink || property.externalLink || property.href; then link; else nolink">
 </ng-container>

--- a/src/app/tools/help-panel/help-panel.component.html
+++ b/src/app/tools/help-panel/help-panel.component.html
@@ -1,29 +1,29 @@
-<div class ="close-button" [dir]="'rtl'">
+<div class="close-button" [dir]="'rtl'">
   <button mat-icon-button (click)="toggleMenu(false)" class="close-button">
     <mat-icon>close</mat-icon>
   </button>
 </div>
-<div class = "help-panel-content" *ngIf="sources && sources.length > 0">
-<!--<div fxLayout="row" class = "search-row">
-  <div fxFlex>
-  <mat-form-field class = "full-width-field" [floatLabel] = "'never'">
-    <input matInput
-           placeholder="search help"
-           (keyup.enter)="search()"
-           aria-label="Search"
-           [formControl]="searchCtrl"
-           class ="input-field">
-    <button mat-button mat-icon-button matSuffix aria-label="search"><mat-icon>search</mat-icon></button>
-  </mat-form-field>
-</div>
-</div>-->
+<div class="help-panel-content" *ngIf="sources && sources.length > 0">
+  <!--<div fxLayout="row" class = "search-row">
+    <div fxFlex>
+    <mat-form-field class = "full-width-field" [floatLabel] = "'never'">
+      <input matInput
+             placeholder="search help"
+             (keyup.enter)="search()"
+             aria-label="Search"
+             [formControl]="searchCtrl"
+             class ="input-field">
+      <button mat-button mat-icon-button matSuffix aria-label="search"><mat-icon>search</mat-icon></button>
+    </mat-form-field>
+  </div>
+  </div>-->
 
-  <div class = "description-row">
+  <div class="description-row">
     <div fxLayout="row" fxLayoutAlign="start center">
-      <span class = "mat-headline"> <strong>{{title}}</strong></span>
+      <span class="mat-headline"> <strong>{{title}}</strong></span>
     </div>
     <div fxLayout="row" fxLayoutAlign="space-around start" *ngIf="description">
-      <div fxFlex = "95">
+      <div fxFlex="95">
         {{description}}
       </div>
     </div>
@@ -35,49 +35,52 @@
       <mat-expansion-panel-header>
         <span class="mat-headline">Descriptions and Definitions</span>
       </mat-expansion-panel-header>
-        <ng-template matExpansionPanelContent *ngIf=" sources.length">
-          <div class = "description-row"  *ngFor="let source of sources; let i = index;">
+      <ng-template matExpansionPanelContent *ngIf="sources.length">
+        <div class="description-row" *ngFor="let source of sources; let i = index;">
+          <div *ngIf="source.label">
             <div fxLayout="row" fxLayoutAlign="start center">
-            <span class = "mat-subheading-1"> <strong>{{source.label}}:</strong></span>
-          </div>
-          <div fxLayout="row" fxLayoutAlign="space-around start">
-            <div fxFlex = "95">
-              <p class="mat-body">{{source.description}}</p>
-              <button *ngIf="source.article && !opened[i]" mat-stroked-button [color]="'primary'" (click)="showArticle(source, i)">
-                Learn More...
-              </button>
-              <button *ngIf="source.article && opened[i]" mat-stroked-button [color]="'primary'" (click)="closeArticle(i)">
-                Close
-              </button>
-              <ng-template cdkPortalOutlet>
-              </ng-template>
-              <br>
+              <span class="mat-subheading-1"> <strong>{{source.label}}:</strong></span>
+            </div>
+            <div fxLayout="row" fxLayoutAlign="space-around start">
+              <div fxFlex="95">
+                <p class="mat-body">{{source.description}}</p>
+                <button *ngIf="source.article && !opened[i]" mat-stroked-button [color]="'primary'"
+                        (click)="showArticle(source, i)">
+                  Learn More...
+                </button>
+                <button *ngIf="source.article && opened[i]" mat-stroked-button [color]="'primary'"
+                        (click)="closeArticle(i)">
+                  Close
+                </button>
+                <ng-template cdkPortalOutlet>
+                </ng-template>
+                <br>
+              </div>
             </div>
           </div>
-          </div>
-        </ng-template>
+        </div>
+      </ng-template>
     </mat-expansion-panel>
 
-<!--        <mat-expansion-panel [expanded]="true">
-          <mat-expansion-panel-header>
-            <span class="mat-headline">Related Topics</span>
-          </mat-expansion-panel-header>
-          <ng-template matExpansionPanelContent>
+    <!--        <mat-expansion-panel [expanded]="true">
+              <mat-expansion-panel-header>
+                <span class="mat-headline">Related Topics</span>
+              </mat-expansion-panel-header>
+              <ng-template matExpansionPanelContent>
 
-          </ng-template>
-        </mat-expansion-panel>-->
+              </ng-template>
+            </mat-expansion-panel>-->
 
-        <mat-expansion-panel>
-          <mat-expansion-panel-header>
-            <span class="mat-headline">Raw Data</span>
-          </mat-expansion-panel-header>
-          <ng-template matExpansionPanelContent>
-            <div fxLayout="row" class = "search-row">
-              <ngx-json-viewer [json] = rawData></ngx-json-viewer>
-            </div>
-          </ng-template>
-        </mat-expansion-panel>
-
+    <mat-expansion-panel>
+      <mat-expansion-panel-header>
+        <span class="mat-headline">Raw Data</span>
+      </mat-expansion-panel-header>
+      <ng-template matExpansionPanelContent>
+        <div fxLayout="row" class="search-row">
+          <ngx-json-viewer [json]=rawData></ngx-json-viewer>
+        </div>
+      </ng-template>
+    </mat-expansion-panel>
 
 
   </mat-accordion>

--- a/src/config/components-config.ts
+++ b/src/config/components-config.ts
@@ -114,18 +114,93 @@ const _APIURL = _HOST + _API;
  */
 const TARGET_TABLE_COMPONENT: PharosPanel = {
   token: TOKENS.TARGET_TABLE_COMPONENT,
+  navHeader: {
+    mainDescription: 'Shows the list of targets matching the search term, and facet selections.',
+    section: 'targetList',
+    label: 'Target List Details'
+  },
   section: Position.Content,
   api: [
     {
       field: 'facets',
       url: _APIURL + 'targets/search?top=0'
-    }, {
+    },
+    {
       field: 'data',
       url: _APIURL + 'targets?top=10'
+    },
+    {
+      field: 'tdl',
+      label: 'Target Development Level',
+      description: 'A classification of the degree to which proteins are studied or not studied, as evidenced by publications, tool compounds and other features.'
+    },
+    {
+      field: 'gene',
+      label: 'Gene',
+      description: 'Official gene symbol'
+    },
+    {
+      field: 'uniprot',
+      label: 'UniProt',
+      description: 'Primary UniProt accession number'
+    },
+    {
+      field: 'family',
+      label: 'Family',
+      description: 'A broad classification of protein families'
+    },
+    {
+      field: 'ppis',
+      label: 'PPIs',
+      description: 'Number of high confidence protein protein interactions for this target.'
+    },
+    {
+      field: 'pubmed',
+      label: 'PubMed Score',
+      description: 'Jensen Lab generated fractional counting score for the prevalence of this target in PubMed articles.'
+    },
+    {
+      field: 'pubtator',
+      label: 'PubTator Score',
+      description: 'A score based on text mining PubMed data.'
+    },
+    {
+      field: 'abcount',
+      label: 'Antibody Count',
+      description: 'Number of antibodies for this target listed in antibodypedia.com.'
+    },
+    {
+      field: 'novelty',
+      label: 'Novelty',
+      description: 'Tin-X metric for the relative scarcity of specific publications for this target.'
+    },
+    {
+      field: 'stringScore',
+      label: 'StringDB score',
+      description: 'String-DB score representing the confidence in the protein protein interaction.'
+    },
+    {
+      field: 'p_int',
+      label: 'BioPlex p_int',
+      description: 'BioPlex score representing the probability of the protein protein interaction.'
+    },
+    {
+      field: 'p_ni',
+      label: 'BioPlex p_ni',
+      description: 'BioPlex score representing the probability that the interaction detected was non-specific.'
+    },
+    {
+      field: 'p_wrong',
+      label: 'BioPlex p_wrong',
+      description: 'BioPlex score representing the probability that the interacting protein was wrongly identified.'
+    },
+    {
+      field: 'illuminationGraph',
+      label: 'Illumination Graph',
+      description: 'Radar plot depicting the variety of knowledge obtained by Pharos for this target.'
     }
   ]
 };
-
 
 /**
  * main target facet component
@@ -423,7 +498,7 @@ const DISEASE_SOURCE_PANEL: PharosPanel = {
     {
       field: 'diseases',
       label: 'Disease Association Sources',
-     // url: _APIURL + 'targets/_id_/links(kind=ix.idg.models.Disease)',
+      // url: _APIURL + 'targets/_id_/links(kind=ix.idg.models.Disease)',
       description: 'Disease-gene associations mined from Medline Franklid et al, Methods, 2015, 83-89'
     },
     {
@@ -436,7 +511,7 @@ const DISEASE_SOURCE_PANEL: PharosPanel = {
     {
       field: 'tinx',
       label: 'Disease Novelty (Tin-x)',
-     // url: _APIURL + 'tinx/target/_accession_',
+      // url: _APIURL + 'tinx/target/_accession_',
       description: 'TIN-X is an interactive visualization tool for discovering interesting associations between diseases ' +
         'and potential drug targets. Click the \'?\' button for more information.',
       article: ARTICLES.TINX_ARTICLE
@@ -517,6 +592,7 @@ const PDB_PANEL: PharosPanel = {
   api: [
     {
       field: 'pdb',
+      label: 'Data Source',
       url: _APIURL + 'targets/_id_/synonyms(label=PDB%20ID)',
       description: 'Proteins and ligands sourced from the RCSB PDB database'
     }
@@ -591,7 +667,7 @@ const PROTEIN_PROTEIN_PANEL: PharosPanel = {
     {
       field: 'interactions',
       label: 'Protein to Protein Interactions',
-     // url: _APIURL + 'predicates?filter=predicate%3D%27Protein-Protein+Interactions%27+AND+subject.refid%3D_id_',
+      // url: _APIURL + 'predicates?filter=predicate%3D%27Protein-Protein+Interactions%27+AND+subject.refid%3D_id_',
       description: 'List of protein to protein interactions associated with this gene.'
 
     }
@@ -614,7 +690,7 @@ const PUBLICATION_STATISTICS_PANEL: PharosPanel = {
     {
       field: 'pubmed',
       label: 'Pubmed Score',
-     // url: _APIURL + 'targets/_id_/properties(label=NCBI%20Gene%20PubMed%20Count)',
+      // url: _APIURL + 'targets/_id_/properties(label=NCBI%20Gene%20PubMed%20Count)',
       description: `The Pubmed Score (also sometimes referred to as the Jensen Score) is
       derived from text mining a set of Pubmed abstracts.`,
       article: ARTICLES.PUBMED_SCORE_ARTICLE
@@ -622,19 +698,19 @@ const PUBLICATION_STATISTICS_PANEL: PharosPanel = {
     {
       field: 'pmscore',
       label: 'Pubmed Score Timeline',
-     // url: _APIURL + 'targets/_id_/pmscore',
+      // url: _APIURL + 'targets/_id_/pmscore',
       description: 'Timeline of pubmed scores for each available year.'
     },
     {
       field: 'pubtator',
       label: 'Pubtator Score Timeline',
-     // url: _APIURL + 'targets/_id_/pubtator',
+      // url: _APIURL + 'targets/_id_/pubtator',
       description: 'Timeline of pubtator scores for each available year.'
     },
     {
       field: 'patents',
       label: 'Patents Timeline',
-    //  url: _APIURL + 'targets/_id_/patents',
+      //  url: _APIURL + 'targets/_id_/patents',
       description: 'Timeline of patent counts for each available year.'
     }
   ]
@@ -660,19 +736,19 @@ const RELATED_PUBLICATIONS_PANEL: PharosPanel = {
     {
       field: 'publications',
       label: 'Text Mined References',
-     // url: _APIURL + 'targets/_id_/publications?top=10',
+      // url: _APIURL + 'targets/_id_/publications?top=10',
       description: 'Publications associated with this target, as identified using the JensenLab text mining protocol'
     },
     {
       field: 'generifCount',
       label: 'GeneRIF Count',
-     // url: _APIURL + 'targets/_id_/generifs/@count',
+      // url: _APIURL + 'targets/_id_/generifs/@count',
       description: 'Total count of NCBI Gene Reference Into Function hits for target listed in parenthesis'
     },
     {
       field: 'generifs',
       label: 'GeneRIFs',
-    //  url: _APIURL + 'targets/_id_/generifs',
+      //  url: _APIURL + 'targets/_id_/generifs',
       description: 'Total count of NCBI Gene Reference Into Function hits for target listed in parenthesis, ' +
         'and summary table with links to publications per PMID with the specific text in article that includes ' +
         'the reported target.'
@@ -695,7 +771,7 @@ const AA_SEQUENCE_PANEL: PharosPanel = {
     {
       field: 'sequence',
       label: 'Sequence',
-     // url: _APIURL + 'targets/_id_/properties(label=UniProt%20Sequence)',
+      // url: _APIURL + 'targets/_id_/properties(label=UniProt%20Sequence)',
       description: 'Amino acid sequence of target protein, bar graph summarizing quantity of each amino acid. ' +
         'Click on looking glass icon for ability to conduct sequence search.'
     },
@@ -722,7 +798,7 @@ const TARGET_FACET_PANEL: PharosPanel = {
     {
       field: 'pantherProteinClass',
       label: 'Panther Protein Class',
-     // url: _APIURL + 'targets/_id_/properties(label=PANTHER%20Protein%20Class*)',
+      // url: _APIURL + 'targets/_id_/properties(label=PANTHER%20Protein%20Class*)',
       description: `The PANTHER (Protein ANalysis THrough Evolutionary Relationships) Classification System was designed
        to classify proteins (and their genes) in order to facilitate high-throughput analysis. The PANTHER
        Classifications are the result of human curation as well as sophisticated bioinformatics algorithms.`,
@@ -731,14 +807,14 @@ const TARGET_FACET_PANEL: PharosPanel = {
     {
       field: 'goFunction',
       label: 'GO Function',
-   //   url: _APIURL + 'targets/_id_/properties(label=GO%20Function*)',
+      //   url: _APIURL + 'targets/_id_/properties(label=GO%20Function*)',
       description: 'Function listed by GO database for target, with total count listed in parenthesis. ' +
         'Listing individual functions with links to GO. Click on bargraph icon to explore further the Summary of GO Function.'
     },
     {
       field: 'goComponent',
       label: 'GO Component',
-    //  url: _APIURL + 'targets/_id_/properties(label=GO%20Component*)',
+      //  url: _APIURL + 'targets/_id_/properties(label=GO%20Component*)',
       description: 'Cellular component listed by GO database for target, with total count listed in ' +
         'parenthesis. Listing individual functions with links to GO. Click on bargraph icon to explore further ' +
         'the Summary of GO Function.'
@@ -746,7 +822,7 @@ const TARGET_FACET_PANEL: PharosPanel = {
     {
       field: 'goProcess',
       label: 'GO Process',
-     // url: _APIURL + 'targets/_id_/properties(label=GO%20Process*)',
+      // url: _APIURL + 'targets/_id_/properties(label=GO%20Process*)',
       description: 'Biological process listed by GO database for target, with total count listed in parenthesis.' +
         'Listing individual functions with links to GO. Click on bargraph icon to explore further the Summary ' +
         'of GO Function.'
@@ -756,7 +832,7 @@ const TARGET_FACET_PANEL: PharosPanel = {
       }, {*/
       field: 'gwasTrait',
       label: 'GWAS Trait',
-   //   url: _APIURL + 'targets/_id_/properties(label=GWAS%20Trait*)',
+      //   url: _APIURL + 'targets/_id_/properties(label=GWAS%20Trait*)',
       description: ` The GWAS Catalog provides a consistent, searchable, visualisable and freely available database of
       published SNP-trait associations.`,
       source: 'https://www.ebi.ac.uk/gwas/home'
@@ -764,21 +840,21 @@ const TARGET_FACET_PANEL: PharosPanel = {
     {
       field: 'rnaCellLine',
       label: 'RNA Cell Line',
-    //  url: _APIURL + 'targets/_id_/properties(label=HCA%20RNA%20Cell%20Line*)',
+      //  url: _APIURL + 'targets/_id_/properties(label=HCA%20RNA%20Cell%20Line*)',
       description: `RNA Cell lines listed in the Human Cell Atlas`,
       source: `https://www.humancellatlas.org/`
     },
     {
       field: 'omim',
       label: 'OMIM Term',
-    //  url: _APIURL + 'targets/_id_/properties(label=OMIM%20Term*)',
+      //  url: _APIURL + 'targets/_id_/properties(label=OMIM%20Term*)',
       description: `Terms listed in the OMIM (Online Mendelian Inheritance in Man) database.`,
       source: 'https://www.omim.org/'
     },
     {
       field: 'uniprotKeyword',
       label: 'Uniprot Keyword',
-    //  url: _APIURL + 'targets/_id_/properties(label=UniProt%20Keyword*)',
+      //  url: _APIURL + 'targets/_id_/properties(label=UniProt%20Keyword*)',
       description: 'Occurrence of target in the 10 categories of UniProt keywords.'
     }
   ]
@@ -853,8 +929,7 @@ const TARGET_LIST_PANEL: PharosPanel = {
  */
 const LIGAND_TABLE_COMPONENT: PharosPanel = {
   token: TOKENS.LIGAND_TABLE_COMPONENT,
-  api: [
-  ]
+  api: []
 };
 
 /**
@@ -986,7 +1061,8 @@ export const COMPONENTSCONFIG: Map<string, any> = new Map<string, any>(
           PHAROS_FACETS_COMPONENT,
           PHAROS_FACET_VISUALIZATION_COMPONENT,
           PHAROS_SELECTED_FACET_LIST_COMPONENT,
-          TARGET_TABLE_COMPONENT
+          TARGET_TABLE_COMPONENT,
+          PHAROS_HELPPANEL_COMPONENT
         ]
       },
       details: {
@@ -1044,7 +1120,7 @@ export const COMPONENTSCONFIG: Map<string, any> = new Map<string, any>(
           LIGAND_DESCRIPTION_COMPONENT,
           LIGAND_DETAILS_COMPONENT,
           TARGET_RELEVANCE_PANEL,
-        //  MOLECULAR_DEFINITION_PANEL
+          //  MOLECULAR_DEFINITION_PANEL
         ]
       }
     }]

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -91,6 +91,7 @@ a:hover {
 
 .paginator-row {
   background-color: #ffffff;
+  padding-left: 16px;
 }
 
 /*pharos-custom-paginator.mat-paginator {

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -5,7 +5,8 @@
     "module": "commonjs"
   },
   "files": [
-    "src/main.server.ts"
+    "src/main.server.ts",
+    "server.ts"
   ],
   "angularCompilerOptions": {
     "entryModule": "./src/app/app.server.module#AppServerModule"


### PR DESCRIPTION
Big stuff: 
Show PPI details on PPI cards on target details page
Revamp target list to use cards, show more info, show tooltips & help panel, show PPI details for PPI target lists. make it work for selecting subsets of targets for saving.
Fix sorting of the target list

Smaller stuff:
don't pass list of facets for "all facets" queries, just let server figure it out
fix caching and some silent crashes (infinite spinning)
show error details when there's a silent crash
link to string-db for PPIs
allow a custom tooltip on DataProperty display