### PR TITLE
KaTeX rendering fix

### DIFF
--- a/delete_unused_katex_fonts.js
+++ b/delete_unused_katex_fonts.js
@@ -1,0 +1,14 @@
+const buildDirectory = './dist/browser/';
+
+var fs = require('fs');
+var files = fs.readdirSync(buildDirectory);
+let katexPattern = /\bKaTeX.+(.ttf|.woff|woff2)/;
+let fontPattern = /(Main-Regular|Math-Italic|Size1-Regular|Size2-Regular)/;
+for(let i = 0 ; i < files.length ; i++){
+  if(files[i].match(katexPattern)) {
+    if(!files[i].match(fontPattern)){
+      fs.unlinkSync(buildDirectory + files[i]);
+      console.log('deleting unused font file : ' + files[i]);
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build pharos --prod",
+    "postbuild" : "node ./delete_unused_katex_fonts.js",
     "test": "ng test pharos --code-coverage",
     "lint": "ng lint pharos",
     "lintfix": "ng lint pharos --fix",

--- a/src/app/tools/equation-renderer/services/katex-render.service.ts
+++ b/src/app/tools/equation-renderer/services/katex-render.service.ts
@@ -54,38 +54,38 @@ export class SplitAtDelimiters {
     const finalData = [];
 
     startData.forEach( text => {
-      if (text === 'text') {
+      if (text.type === 'text') {
         let lookingForLeft = true;
         let currIndex = 0;
         let nextIndex;
 
-        nextIndex = text.indexOf(leftDelim);
+        nextIndex = text.data.indexOf(leftDelim);
         if (nextIndex !== -1) {
           currIndex = nextIndex;
           finalData.push({
             type: 'text',
-            data: text.slice(0, currIndex),
+            data: text.data.slice(0, currIndex),
           });
           lookingForLeft = false;
         }
 
         while (true) {
           if (lookingForLeft) {
-            nextIndex = text.indexOf(leftDelim, currIndex);
+            nextIndex = text.data.indexOf(leftDelim, currIndex);
             if (nextIndex === -1) {
               break;
             }
 
             finalData.push({
               type: 'text',
-              data: text.slice(currIndex, nextIndex),
+              data: text.data.slice(currIndex, nextIndex),
             });
 
             currIndex = nextIndex;
           } else {
             nextIndex = this.findEndOfMath(
               rightDelim,
-              text,
+              text.data,
               currIndex + leftDelim.length);
             if (nextIndex === -1) {
               break;
@@ -93,10 +93,10 @@ export class SplitAtDelimiters {
 
             finalData.push({
               type: 'math',
-              data: text.slice(
+              data: text.data.slice(
                 currIndex + leftDelim.length,
                 nextIndex),
-              rawData: text.slice(
+              rawData: text.data.slice(
                 currIndex,
                 nextIndex + rightDelim.length),
               display,
@@ -110,7 +110,7 @@ export class SplitAtDelimiters {
 
         finalData.push({
           type: 'text',
-          data: text.slice(currIndex),
+          data: text.data.slice(currIndex),
         });
       } else {
         finalData.push(text);


### PR DESCRIPTION
fixed katex-render.service.ts since splitAtDelimiters gets passed an object array, and uses it like a string. I'm not sure how that ever worked for anyone, or how it got published like that.

added a postbuild step to delete stuff we don't use. It will run when someone builds via "npm run build"
there seems to be no way to hook into "ng build" with a postbuild step without a custom builder