### PR TITLE
don't use top parameter from the URL

### DIFF
--- a/src/app/pharos-services/pharos-api.service.ts
+++ b/src/app/pharos-services/pharos-api.service.ts
@@ -799,7 +799,9 @@ export class PharosApiService {
   }
 
   public downloadQuery(route: ActivatedRouteSnapshot, variables?: any) {
+    const inTop = variables.top;
     variables = {...variables, ...this.parseVariables(route, null)};
+    variables.top = inTop;
     return this.fetchTargetList(route).then((res: string[]) => {
       if (res && res.length > 0) {
         variables.batch = res;


### PR DESCRIPTION
bug fix: if someone goes to the next page, or changes the page size on a list page, the download query will use that page size as the download size. Now, the URL page length parameter is ignored, and the download is the length it's supposed to be.